### PR TITLE
FIXME: Replace all occurences of fastrtpsgen with fastddsgen

### DIFF
--- a/cmake/GenerateMicroRTPSAgent.cmake
+++ b/cmake/GenerateMicroRTPSAgent.cmake
@@ -33,37 +33,37 @@
 #       - templates/uorb_rtps_message_ids.yaml
 #       - scripts/uorb_rtps_classifier.py
 #       - scripts/generate_microRTPS_bridge.py
-#       - FASTRTPSGEN_DIR
+#       - FASTDDSGEN_DIR
 ##################################################################################
 
-# Check if FastRTPSGen exists
-if($ENV{FASTRTPSGEN_DIR})
-  message(STATUS "fastrtpsgen found in $ENV{FASTRTPSGEN_DIR}")
-  set(FASTRTPSGEN "$ENV{FASTRTPSGEN_DIR}/fastrtpsgen")
+# Check if Fastddsgen exists
+if($ENV{FASTDDSGEN_DIR})
+  message(STATUS "fastddsgen found in $ENV{FASTDDSGEN_DIR}")
+  set(FASTDDSGEN "$ENV{FASTDDSGEN_DIR}/fastddsgen")
 else()
-  find_file(FASTRTPSGEN NAMES fastrtpsgen PATH_SUFFIXES bin)
-  if(FASTRTPSGEN-NOTFOUND)
-    message(FATAL_ERROR "fastrtpsgen not found")
+  find_file(FASTDDSGEN NAMES fastddsgen PATH_SUFFIXES bin)
+  if(FASTDDSGEN-NOTFOUND)
+    message(FATAL_ERROR "fastddsgen not found")
   else()
-    get_filename_component(FASTRTPSGEN_DIR ${FASTRTPSGEN} DIRECTORY)
-    message(STATUS "fastrtpsgen found in ${FASTRTPSGEN_DIR}")
+    get_filename_component(FASTDDSGEN_DIR ${FASTDDSGEN} DIRECTORY)
+    message(STATUS "fastddsgen found in ${FASTDDSGEN_DIR}")
   endif()
 endif()
 
-# Get FastRTPSGen version
-set(FASTRTPSGEN_VERSION)
-execute_process(COMMAND fastrtpsgen -version
-                OUTPUT_VARIABLE FASTRTPSGEN_VERSION_OUTPUT
+# Get Fastddsgen version
+set(FASTDDSGEN_VERSION)
+execute_process(COMMAND fastddsgen -version
+                OUTPUT_VARIABLE FASTDDSGEN_VERSION_OUTPUT
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX MATCH
              "([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
-             FASTRTPSGEN_VERSION
-             "${FASTRTPSGEN_VERSION_OUTPUT}")
-# If the above command fails, force FastRTPSGen to 1.0.0
-if(NOT FASTRTPSGEN_VERSION)
-  set(FASTRTPSGEN_VERSION "1.0.0")
+             FASTDDSGEN_VERSION
+             "${FASTDDSGEN_VERSION_OUTPUT}")
+# If the above command fails, force Fastddsgen to 1.0.0
+if(NOT FASTDDSGEN_VERSION)
+  set(FASTDDSGEN_VERSION "1.0.0")
 endif()
-message(STATUS "fastrtpsgen version ${FASTRTPSGEN_VERSION}")
+message(STATUS "fastddsgen version ${FASTDDSGEN_VERSION}")
 
 # Find ROS distro
 set(ROS_DISTRO)
@@ -162,13 +162,13 @@ list(APPEND MICRORTPS_AGENT_FILES ${MICRORTPS_AGENT_DIR}/RtpsTopics.cpp)
 
 set(ALL_TOPIC_NAMES ${CONFIG_RTPS_SEND_TOPICS} ${CONFIG_RTPS_RECEIVE_TOPICS})
 foreach(topic ${ALL_TOPIC_NAMES})
-  # Requires differentiation between FastRTPSGen versions
-  if(FASTRTPSGEN_VERSION VERSION_GREATER 1.4 AND FASTRTPSGEN_VERSION VERSION_LESS 1.8)
+  # Requires differentiation between Fastddsgen versions
+  if(FASTDDSGEN_VERSION VERSION_GREATER 1.4 AND FASTDDSGEN_VERSION VERSION_LESS 1.8)
     list(APPEND MICRORTPS_AGENT_FILES ${MICRORTPS_AGENT_DIR}/${topic}_.cpp)
   else()
     list(APPEND MICRORTPS_AGENT_FILES ${MICRORTPS_AGENT_DIR}/${topic}.cpp)
   endif()
-  if(FASTRTPSGEN_VERSION VERSION_GREATER 1.4 AND FASTRTPSGEN_VERSION VERSION_LESS 1.8)
+  if(FASTDDSGEN_VERSION VERSION_GREATER 1.4 AND FASTDDSGEN_VERSION VERSION_LESS 1.8)
     list(APPEND MICRORTPS_AGENT_FILES
                 ${MICRORTPS_AGENT_DIR}/${topic}_PubSubTypes.cpp)
     list(APPEND MICRORTPS_AGENT_FILES
@@ -196,11 +196,11 @@ foreach(topic ${CONFIG_RTPS_SEND_TOPICS}) # advertised topics should first be
     APPEND MICRORTPS_AGENT_FILES ${MICRORTPS_AGENT_DIR}/${topic}_Subscriber.h)
 endforeach()
 
-message(STATUS "fastrtpsgen found in $ENV{FASTRTPSGEN_DIR}")
+message(STATUS "fastddsgen found in $ENV{FASTDDSGEN_DIR}")
 message(STATUS "px4_msgs message dir under ${MSGS_DIR}")
 
 set(IDL_DIR)
-if(FASTRTPSGEN_VERSION VERSION_GREATER 1.4 AND FASTRTPSGEN_VERSION VERSION_LESS 1.8)
+if(FASTDDSGEN_VERSION VERSION_GREATER 1.4 AND FASTDDSGEN_VERSION VERSION_LESS 1.8)
   set(IDL_DIR "${MSGS_DIR}/dds_fastrtps")
 else()
   set(IDL_DIR "${MSGS_DIR}")
@@ -208,16 +208,16 @@ endif()
 
 message(STATUS "IDL definitions under ${IDL_DIR}")
 
-get_filename_component(px4_msgs_FASTRTPSGEN_INCLUDE "../../" ABSOLUTE BASE_DIR ${px4_msgs_DIR})
+get_filename_component(px4_msgs_FASTDDSGEN_INCLUDE "../../" ABSOLUTE BASE_DIR ${px4_msgs_DIR})
 add_custom_command(
   OUTPUT  ${MICRORTPS_AGENT_FILES}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_microRTPS_bridge.py
-          $ENV{FASTRTPSGEN_DIR}
+          $ENV{FASTDDSGEN_DIR}
   COMMAND
     ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_microRTPS_bridge.py
-    --fastrtpsgen-dir $ENV{FASTRTPSGEN_DIR}
-    --fastrtpsgen-include ${px4_msgs_FASTRTPSGEN_INCLUDE}
+    --fastddsgen-dir $ENV{FASTDDSGEN_DIR}
+    --fastddsgen-include ${px4_msgs_FASTDDSGEN_INCLUDE}
     --topic-msg-dir ${MSGS_DIR}
     --urtps-templates-dir ${CMAKE_CURRENT_SOURCE_DIR}/templates
     --rtps-ids-file ${CMAKE_CURRENT_SOURCE_DIR}/templates/uorb_rtps_message_ids.yaml

--- a/scripts/build_all.bash
+++ b/scripts/build_all.bash
@@ -30,23 +30,23 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# Check FastRTPSGen version
-fastrtpsgen_version_out=""
-if [[ -z $FASTRTPSGEN_DIR ]]; then
-  fastrtpsgen_version_out="$FASTRTPSGEN_DIR/$(fastrtpsgen -version)"
+# Check FastDDSGen version
+fastddsgen_version_out=""
+if [[ -z $FASTDDSGEN_DIR ]]; then
+  fastddsgen_version_out="$FASTDDSGEN_DIR/$(fastddsgen -version)"
 else
-  fastrtpsgen_version_out=$(fastrtpsgen -version)
+  fastddsgen_version_out=$(fastddsgen -version)
 fi
-if [[ -z $fastrtpsgen_version_out ]]; then
-  echo "FastRTPSGen not found! Please build and install FastRTPSGen..."
+if [[ -z $fastddsgen_version_out ]]; then
+  echo "Fastddsgen not found! Please build and install Fastddsgen..."
   exit 1
 else
-  fastrtpsgen_version="${fastrtpsgen_version_out: -5:-2}"
-  if ! [[ $fastrtpsgen_version =~ ^[0-9]+([.][0-9]+)?$ ]] ; then
-    fastrtpsgen_version="1.0"
-    echo "FastRTPSGen version: ${fastrtpsgen_version}"
+  fastddsgen_version="${fastddsgen_version_out: -5:-2}"
+  if ! [[ $fastddsgen_version =~ ^[0-9]+([.][0-9]+)?$ ]] ; then
+    fastddsgen_version="1.0"
+    echo "Fastddsgen version: ${fastddsgen_version}"
   else
-    echo "FastRTPSGen version: ${fastrtpsgen_version_out: -5}"
+    echo "Fastddsgen version: ${fastddsgen_version_out: -5}"
   fi
 fi
 

--- a/scripts/build_ros2_workspace.bash
+++ b/scripts/build_ros2_workspace.bash
@@ -28,23 +28,23 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# Check FastRTPSGen version
-fastrtpsgen_version_out=""
-if [[ -z $FASTRTPSGEN_DIR ]]; then
-  fastrtpsgen_version_out="$FASTRTPSGEN_DIR/$(fastrtpsgen -version)"
+# Check Fastddsgen version
+fastddsgen_version_out=""
+if [[ -z $FASTDDSGEN_DIR ]]; then
+  fastddsgen_version_out="$FASTDDSGEN_DIR/$(fastddsgen -version)"
 else
-  fastrtpsgen_version_out=$(fastrtpsgen -version)
+  fastddsgen_version_out=$(fastddsgen -version)
 fi
-if [[ -z $fastrtpsgen_version_out ]]; then
-  echo "FastRTPSGen not found! Please build and install FastRTPSGen..."
+if [[ -z $fastddsgen_version_out ]]; then
+  echo "Fastddsgen not found! Please build and install Fastddsgen..."
   exit 1
 else
-  fastrtpsgen_version="${fastrtpsgen_version_out: -5:-2}"
-  if ! [[ $fastrtpsgen_version =~ ^[0-9]+([.][0-9]+)?$ ]] ; then
-    fastrtpsgen_version="1.0"
-    [ ! -v $verbose ] && echo "FastRTPSGen version: ${fastrtpsgen_version}"
+  fastddsgen_version="${fastddsgen_version_out: -5:-2}"
+  if ! [[ $fastddsgen_version =~ ^[0-9]+([.][0-9]+)?$ ]] ; then
+    fastddsgen_version="1.0"
+    [ ! -v $verbose ] && echo "Fastddsgen version: ${fastddsgen_version}"
   else
-    [ ! -v $verbose ] && echo "FastRTPSGen version: ${fastrtpsgen_version_out: -5}"
+    [ ! -v $verbose ] && echo "Fastddsgen version: ${fastddsgen_version_out: -5}"
   fi
 fi
 

--- a/scripts/generate_microRTPS_bridge.py
+++ b/scripts/generate_microRTPS_bridge.py
@@ -33,9 +33,9 @@
 ################################################################################
 
 # This script can generate the client and agent code based on a set of topics
-# to sent and set to receive. It uses fastrtpsgen to generate the code from the
+# to sent and set to receive. It uses fastddsgen to generate the code from the
 # IDL for the topic messages. The PX4 msg definitions are used to create the IDL
-# used by fastrtpsgen using templates.
+# used by fastddsgen using templates.
 
 import sys
 import os
@@ -175,10 +175,10 @@ parser.add_argument("-o", "--agent-outdir", dest='agentdir', type=str,
                     help="Agent output dir, by default using relative path 'src/modules/micrortps_bridge/micrortps_agent'", default=default_agent_out)
 parser.add_argument("-u", "--client-outdir", dest='clientdir', type=str,
                     help="Client output dir, by default using relative path 'src/modules/micrortps_bridge/micrortps_client'", default=default_client_out)
-parser.add_argument("-f", "--fastrtpsgen-dir", dest='fastrtpsgen', type=str, nargs='?',
-                    help="fastrtpsgen installation dir, only needed if fastrtpsgen is not in PATH, by default empty", default="")
-parser.add_argument("-g", "--fastrtpsgen-include", dest='fastrtpsgen_include', type=str,
-                    help="directory(ies) to add to preprocessor include paths of fastrtpsgen, by default empty", default="")
+parser.add_argument("-f", "--fastddsgen-dir", dest='fastddsgen', type=str, nargs='?',
+                    help="fastddsgen installation dir, only needed if fastddsgen is not in PATH, by default empty", default="")
+parser.add_argument("-g", "--fastddsgen-include", dest='fastddsgen_include', type=str,
+                    help="directory(ies) to add to preprocessor include paths of fastddsgen, by default empty", default="")
 parser.add_argument("-r", "--ros2-distro", dest='ros2_distro', type=str, nargs='?',
                     help="ROS2 distro, only required if generating the agent for usage with ROS2 nodes, by default empty", default="")
 parser.add_argument("--delete-tree", dest='del_tree',
@@ -217,48 +217,48 @@ if idl_dir != '':
 else:
     idl_dir = os.path.join(agent_out_dir, "idl")
 
-if args.fastrtpsgen is None or args.fastrtpsgen == '':
-    # Assume fastrtpsgen is in PATH
-    fastrtpsgen_path = 'fastrtpsgen'
+if args.fastddsgen is None or args.fastddsgen == '':
+    # Assume fastddsgen is in PATH
+    fastddsgen_path = 'fastddsgen'
     for dirname in os.environ['PATH'].split(':'):
-        candidate = os.path.join(dirname, 'fastrtpsgen')
+        candidate = os.path.join(dirname, 'fastddsgen')
         if os.path.isfile(candidate):
-            fastrtpsgen_path = candidate
+            fastddsgen_path = candidate
 else:
-    # Path to fastrtpsgen is explicitly specified
-    if os.path.isdir(args.fastrtpsgen):
-        fastrtpsgen_path = os.path.join(
-            os.path.abspath(args.fastrtpsgen), 'fastrtpsgen')
+    # Path to fastddsgen is explicitly specified
+    if os.path.isdir(args.fastddsgen):
+        fastddsgen_path = os.path.join(
+            os.path.abspath(args.fastddsgen), 'fastddsgen')
     else:
-        fastrtpsgen_path = args.fastrtpsgen
+        fastddsgen_path = args.fastddsgen
 
-fastrtpsgen_include = args.fastrtpsgen_include
-if fastrtpsgen_include is not None and fastrtpsgen_include != '':
-    fastrtpsgen_include = "-I " + \
+fastddsgen_include = args.fastddsgen_include
+if fastddsgen_include is not None and fastddsgen_include != '':
+    fastddsgen_include = "-I " + \
         os.path.abspath(
-            args.fastrtpsgen_include) + " "
+            args.fastddsgen_include) + " "
 
-# get FastRTPSGen version
-# .. note:: since Fast-RTPS 1.8.0 release, FastRTPSGen is a separated repository
+# get Fastddsgen version
+# .. note:: since Fast-RTPS 1.8.0 release, Fastddsgen is a separated repository
 # and not included in the Fast-RTPS project.
 # The starting version since this separation is 1.0.0, which follows its own
 # versioning
-fastrtpsgen_version = version.Version("1.0.0")
-if(os.path.exists(fastrtpsgen_path)):
+fastddsgen_version = version.Version("1.0.0")
+if(os.path.exists(fastddsgen_path)):
     try:
-        fastrtpsgen_version_out = subprocess.check_output(
-            [fastrtpsgen_path, "-version"]).decode("utf-8").strip()[-5:]
+        fastddsgen_version_out = subprocess.check_output(
+            [fastddsgen_path, "-version"]).decode("utf-8").strip()[-5:]
     except OSError:
         raise
 
     try:
-        fastrtpsgen_version = version.parse(fastrtpsgen_version_out)
+        fastddsgen_version = version.parse(fastddsgen_version_out)
     except version.InvalidVersion:
         raise Exception(
-            "'fastrtpsgen -version' returned None or an invalid version")
+            "'fastddsgen -version' returned None or an invalid version")
 else:
     raise Exception(
-        "FastRTPSGen not found. Specify the location of fastrtpsgen with the -f flag")
+        "Fastddsgen not found. Specify the location of fastddsgen with the -f flag")
 
 
 # get ROS 2 version, if exists
@@ -418,35 +418,35 @@ def generate_agent(out_dir):
                                                             urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
 
     # Final steps to install agent
-    mkdir_p(os.path.join(out_dir, "fastrtpsgen"))
+    mkdir_p(os.path.join(out_dir, "fastddsgen"))
     prev_cwd_path = os.getcwd()
-    os.chdir(os.path.join(out_dir, "fastrtpsgen"))
+    os.chdir(os.path.join(out_dir, "fastddsgen"))
     if not glob.glob(os.path.join(idl_dir, "*.idl")):
         raise Exception("No IDL files found in %s" % idl_dir)
 
     # If it is generating the bridge code for interfacing with ROS2, then set
-    # the '-typeros2' option in fastrtpsgen.
-    # .. note:: This is only available in FastRTPSGen 1.0.4 and above
+    # the '-typeros2' option in fastddsgen.
+    # .. note:: This is only available in Fastddsgen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy'] and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy'] and fastddsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     for idl_file in glob.glob(os.path.join(idl_dir, "*.idl")):
         try:
-            ret = subprocess.check_call(fastrtpsgen_path + " -d " + out_dir +
-                                        "/fastrtpsgen -example x64Linux2.6gcc " + gen_ros2_typename + fastrtpsgen_include + idl_file, shell=True)
+            ret = subprocess.check_call(fastddsgen_path + " -d " + out_dir +
+                                        "/fastddsgen -example x64Linux2.6gcc " + gen_ros2_typename + fastddsgen_include + idl_file, shell=True)
         except OSError:
             raise
 
-    rm_wildcard(os.path.join(out_dir, "fastrtpsgen/*PubSubMain*"))
-    rm_wildcard(os.path.join(out_dir, "fastrtpsgen/makefile*"))
-    rm_wildcard(os.path.join(out_dir, "fastrtpsgen/*Publisher*"))
-    rm_wildcard(os.path.join(out_dir, "fastrtpsgen/*Subscriber*"))
-    for f in glob.glob(os.path.join(out_dir, "fastrtpsgen/*.cxx")):
+    rm_wildcard(os.path.join(out_dir, "fastddsgen/*PubSubMain*"))
+    rm_wildcard(os.path.join(out_dir, "fastddsgen/makefile*"))
+    rm_wildcard(os.path.join(out_dir, "fastddsgen/*Publisher*"))
+    rm_wildcard(os.path.join(out_dir, "fastddsgen/*Subscriber*"))
+    for f in glob.glob(os.path.join(out_dir, "fastddsgen/*.cxx")):
         os.rename(f, f.replace(".cxx", ".cpp"))
-    cp_wildcard(os.path.join(out_dir, "fastrtpsgen/*"), out_dir)
-    if os.path.isdir(os.path.join(out_dir, "fastrtpsgen")):
-        shutil.rmtree(os.path.join(out_dir, "fastrtpsgen"))
+    cp_wildcard(os.path.join(out_dir, "fastddsgen/*"), out_dir)
+    if os.path.isdir(os.path.join(out_dir, "fastddsgen")):
+        shutil.rmtree(os.path.join(out_dir, "fastddsgen"))
     cp_wildcard(os.path.join(urtps_templates_dir,
                              "microRTPS_transport.*"), agent_out_dir)
     if cmakelists:

--- a/scripts/setup_system.bash
+++ b/scripts/setup_system.bash
@@ -114,8 +114,8 @@ else
   git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen \
     && cd /tmp/Fast-RTPS-Gen \
     && gradle assemble \
-    && sudo cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
-    && sudo cp scripts/fastrtpsgen /usr/local/bin/ \
+    && sudo cp share/fastrtps/fastddsgen.jar /usr/local/share/fastrtps/ \
+    && sudo cp scripts/fastddsgen /usr/local/bin/ \
     && cd $PWD
 fi
 


### PR DESCRIPTION
This is quick-and-dirty for switching to fast-dds-gen v2. Probably
this should be done in a way that is compatible also with fast-rtps-gen 1.0.4

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>