### PR TITLE
Avoid receiving incomplete UDP packages due to buffer overflow

### DIFF
--- a/templates/microRTPS_agent.cpp.em
+++ b/templates/microRTPS_agent.cpp.em
@@ -308,6 +308,8 @@ int main(int argc, char** argv)
             end = std::chrono::steady_clock::now();
         }
 
+        if (_options.verbose_debug) printf("\033[0;31m[ micrortps_transport ]\ttransport_node returned %d\033[0m\n", length);
+
         if ((receiving && std::chrono::duration<double>(std::chrono::steady_clock::now() - end).count() > WAIT_CNST) ||
             (!running  && loop > 1))
         {

--- a/templates/microRTPS_transport.cpp
+++ b/templates/microRTPS_transport.cpp
@@ -111,6 +111,12 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 		return -1;
 	}
 
+	if (rx_buff_pos > BUFFER_FLUSH_THRESHOLD)
+	{
+		if (debug) printf("\033[0;31m[ micrortps_transport ]\tBuffer close to overflow - flushing.. \033[0m\n");
+		rx_buff_pos = 0;
+	}
+
 	*topic_ID = 255;
 
 	ssize_t len = node_read((void *)(rx_buffer + rx_buff_pos), sizeof(rx_buffer) - rx_buff_pos);

--- a/templates/microRTPS_transport.h
+++ b/templates/microRTPS_transport.h
@@ -40,7 +40,12 @@
 
 #define BUFFER_SIZE 1024
 #define DEFAULT_UART "/dev/ttyACM0"
-
+#define MAX_MICRORTPS_MSG_SIZE 300
+#if ( (MAX_MICRORTPS_MSG_SIZE*2) > BUFFER_SIZE )
+    #error "BUFFER_SIZE shall be bigger than size of two messages!"
+#endif
+#define BUFFER_FLUSH_THRESHOLD (BUFFER_SIZE - MAX_MICRORTPS_MSG_SIZE)
+#
 class Transport_node
 {
 public:


### PR DESCRIPTION
When receiving UDP packet that is bigger than available buffer size
the excess bytes are discarded. Parser handling slows down due to errors
and it never reach to the point that there would be enough free space to
receive complete packets. The parser never recover from that unless recv
buffer is flushed to empty to make enough free space for complete packet.