### PR TITLE
add more sensors for state estimator

### DIFF
--- a/templates/uorb_rtps_message_ids.yaml
+++ b/templates/uorb_rtps_message_ids.yaml
@@ -38,6 +38,7 @@ rtps:
     msg: DifferentialPressure
   - id: 17
     msg: DistanceSensor
+    send: true
   - id: 18
     msg: EstimatorInnovations
   - id: 19
@@ -138,6 +139,7 @@ rtps:
     msg: SensorAccel
   - id: 63
     msg: SensorBaro
+    send: true
   - id: 64
     msg: EstimatorSensorBias
   - id: 65


### PR DESCRIPTION
For our implementation of a state estimator, we will need these PX4 topics to be enabled:
- baro sensor
- distance sensor