### PR TITLE
Simplified timesync

### DIFF
--- a/templates/RtpsTopics.h.em
+++ b/templates/RtpsTopics.h.em
@@ -93,7 +93,7 @@ using @(topic)_msg_t = @(topic);
 
 class RtpsTopics {
 public:
-    bool init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue, const std::string& ns, const std::vector<std::string>& whitelist);
+    bool init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue, const std::string& ns, const std::vector<std::string>& whitelist, const uint32_t transmission_speed_bytes_per_sec);
     void set_timesync(const std::shared_ptr<TimeSync>& timesync) { _timesync = timesync; };
 @[if send_topics]@
     void publish(uint8_t topic_ID, char data_buffer[], size_t len);
@@ -204,4 +204,11 @@ private:
      *         messages timestamps.
      */
     std::shared_ptr<TimeSync> _timesync;
+
+    /**
+     * @@brief Transmission speed.
+     *         Speed (bytes per second) how fast the data goes through the transmission line
+     *         This is used for calculating timestamp for received messages
+     */
+    uint32_t _tr_speed;
 };

--- a/templates/microRTPS_agent.cpp.em
+++ b/templates/microRTPS_agent.cpp.em
@@ -115,7 +115,7 @@ static void usage(const char *name)
 {
     printf("usage: %s [options]\n\n"
              "  -a <whitelist>          List of IP numbers of whitelisted interfaces\n"
-             "  -b <baudrate>           UART device baudrate. Default 460800\n"
+             "  -b <baudrate>           UART device baudrate. Default 460800. Used for transmission delay also in UDP case\n"
              "  -d <device>             UART device. Default /dev/ttyACM0\n"
              "  -f <sw flow control>    Activates UART link SW flow control\n"
              "  -h <hw flow control>    Activates UART link HW flow control\n"
@@ -285,7 +285,7 @@ int main(int argc, char** argv)
     }
 
 @[if recv_topics]@
-    topics.init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue, _options.ns, whitelist);
+    topics.init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue, _options.ns, whitelist, _options.baudrate);
 @[end if]@
 
     running = true;


### PR DESCRIPTION
Deliver only time delta from original TS to the time message is sent. In receiving end add current time to the received delta. In addition to that the micrortps_agent side adds the transmission delay.