### PR TITLE
Define fastrtps profile to prevent shm transport between containers

### DIFF
--- a/DEFAULT_FASTRTPS_PROFILES.xml
+++ b/DEFAULT_FASTRTPS_PROFILES.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<profiles> 
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>ContainerTransport</transport_id>
+            <type>UDPv4</type>
+        </transport_descriptor>
+    </transport_descriptors>
+    <participant profile_name="participant_profile_fog_sw" is_default_profile="true"> 
+        <rtps> 
+            <builtin>
+                <discovery_config>
+                    <leaseDuration>
+                        <!-- DURATION -->
+                        <sec>20</sec>
+                        <nanosec>0</nanosec>
+                    </leaseDuration>
+
+                    <leaseAnnouncement>
+                        <!-- DURATION -->
+                        <sec>10</sec>
+                        <nanosec>0</nanosec>
+                    </leaseAnnouncement>
+                </discovery_config>
+            </builtin> 
+
+            <userTransports>
+                <transport_id>ContainerTransport</transport_id>
+            </userTransports>
+            <useBuiltinTransports>false</useBuiltinTransports>
+        </rtps> 
+    </participant> 
+    <data_writer profile_name="datawriter_profile_fog_sw" is_default_profile="true">
+        <qos> <!-- dataWriterQosPoliciesType -->
+            <durability>
+                <kind>VOLATILE</kind>
+            </durability>
+            <reliability>
+                <kind>BEST_EFFORT</kind>
+            </reliability>
+        </qos>
+    </data_writer>
+    <data_reader profile_name="datareader_profile_fog_sw"  is_default_profile="true">
+        <qos> <!-- dataReaderQosPoliciesType -->
+            <durability>
+                <kind>VOLATILE</kind>
+            </durability>
+            <reliability>
+                <kind>BEST_EFFORT</kind>
+            </reliability>
+        </qos>
+    </data_reader>
+</profiles>

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN sed --in-place \
       /$PACKAGE_NAME/entrypoint.sh && \  
         chmod +x /$PACKAGE_NAME/entrypoint.sh
 
+ENV FASTRTPS_DEFAULT_PROFILES_FILE /$PACKAGE_NAME/main_ws/src/DEFAULT_FASTRTPS_PROFILES.xml
 ENV PACKAGE_NAME $PACKAGE_NAME
 WORKDIR /$PACKAGE_NAME
 ENTRYPOINT "/"$PACKAGE_NAME"/entrypoint.sh"


### PR DESCRIPTION
Dronsole simulation has common host network defined in container running in core pod. This makes fastrtps to use SHM for communication between nodes running that the same core pod. If some of the containers runs ROS2 with different user privilege, the communication get stuck in SHM access.
Using UDPv4 only for inter-container communication prevents any permission issues.