### PR TITLE
Support for direct ethernet connection to FC

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,11 @@
-#!/bin/bash
+#!/bin/bash -e
 
 source /opt/ros/galactic/setup.bash
 
-micrortps_agent -t UDP -n "$DRONE_DEVICE_ID"
+if [ "${FLIGHT_CONTROLLER_DIRECT_ETH}" != "" ]; then
+  # Direct ethernet connection to FC
+  exec micrortps_agent -t UDP -b 10000000 -i 192.168.200.101 -n "$DRONE_DEVICE_ID"
+else
+  # FC connection via protocol_splitter/UART
+  exec micrortps_agent -t UDP -b 2000000 -n "$DRONE_DEVICE_ID"
+fi


### PR DESCRIPTION
Direct ethernet connection instead of via protocol_splitter can be
enabled by defining FLIGHT_CONTROLLER_DIRECT_ETH env variable when
docker container is started.

To run docker container with protocol_splitter connection:
 docker run --rm --network=host <docker_image>

To run docker container with direct px4 ethernet connection:
 docker run --rm --network=host --env FLIGHT_CONTROLLER_DIRECT_ETH=1 <docker_image>