### PR TITLE
Fix condition variable wait deadlock

### DIFF
--- a/templates/microRTPS_agent.cpp.em
+++ b/templates/microRTPS_agent.cpp.em
@@ -359,13 +359,10 @@ int main(int argc, char **argv)
 	// Init timesync
 	topics->set_timesync(std::make_shared<TimeSync>(_options.verbose_debug));
 
-@[if recv_topics]@
-	topics->init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue, _options.ns, _options.whitelist, _options.baudrate);
-@[end if]@
-
 	running = true;
 @[if recv_topics]@
 	std::thread sender_thread(t_send, nullptr);
+	topics->init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue, _options.ns, _options.whitelist, _options.baudrate);
 @[end if]@
 
 	while (running) {


### PR DESCRIPTION
Start sender thread before topics init to avoid condition variable deadlock.
If some topic sender was discovered before all topics were initialized and sender thread was started, the thread where topic init was performed started waiting for sender thread to trigger release for condition variable wait. But because the sender thread was not yet started it caused the deadlock situation.